### PR TITLE
fix(admin/profile): reload user data on screen focus

### DIFF
--- a/src/app/(admin)/profile.tsx
+++ b/src/app/(admin)/profile.tsx
@@ -1,6 +1,6 @@
 import { Feather, Ionicons } from '@expo/vector-icons';
-import { useRouter } from 'expo-router';
-import React, { useEffect, useState } from 'react';
+import { useFocusEffect, useRouter } from 'expo-router';
+import React, { useCallback, useState } from 'react';
 import {
   Alert,
   ScrollView,
@@ -29,16 +29,18 @@ export default function AdminProfileScreen() {
   const [emailVerified, setEmailVerified] = useState(false);
   const [initial, setInitial] = useState('A');
 
-  useEffect(() => {
-    const user = auth.currentUser;
-    if (user) {
-      const name = user.displayName || 'Administrador';
-      setDisplayName(name);
-      setEmail(user.email || '');
-      setEmailVerified(user.emailVerified);
-      setInitial((user.displayName || user.email || 'A')[0].toUpperCase());
-    }
-  }, []);
+  useFocusEffect(
+    useCallback(() => {
+      const user = auth.currentUser;
+      if (user) {
+        const name = user.displayName || 'Administrador';
+        setDisplayName(name);
+        setEmail(user.email || '');
+        setEmailVerified(user.emailVerified);
+        setInitial((user.displayName || user.email || 'A')[0].toUpperCase());
+      }
+    }, [])
+  );
 
   const handleLogout = () => {
     Alert.alert(


### PR DESCRIPTION
- Replace useEffect with useFocusEffect + useCallback
- Data (name, email, initial) now refreshes every time the profile tab gains focus, picking up changes made in the 'Meus dados' screen without requiring an app restart